### PR TITLE
sleeper_helper: Stats and projections

### DIFF
--- a/src/NFLLunch/sleeper_helper.py
+++ b/src/NFLLunch/sleeper_helper.py
@@ -6,7 +6,7 @@ import sleeper_wrapper as sleeper
 
 YEAR = datetime.now().year
 LOG = logging.getLogger("NFLLunch.sleeper_helper")
-# helper = SleeperHelper(sleeper, 11)
+SEASON_TYPES = ['pre', 'regular', 'post']
 
 
 class SleeperHelper:
@@ -67,6 +67,65 @@ class SleeperHelper:
             if def_name in [t.lower() for t in list(v.values())]:
                 return def_id
         return None
+
+    def player_week_stats(
+        self, player_id: Union[str, int], season_type: str,
+        week: Union[str, int]
+    ) -> dict:
+        """
+            Return stats for a given player
+        """
+        if season_type not in SEASON_TYPES:
+            logging.warning(
+                "'%s' is not a valid season type. Valid options are: %s".format(
+                    season_type, ', '.join(SEASON_TYPES)
+                )
+            )
+            return None
+        return self.client.Stats().get_week_stats(
+            season_type, YEAR, week)[str(player_id)]
+
+    def player_season_stats(
+        self, player_id: Union[str, int], season_type: str
+    ) -> dict:
+        """
+            Return stats for a given player
+        """
+        if season_type not in SEASON_TYPES:
+            logging.warning(
+                "'%s' is not a valid season type. Valid options are: %s".format(
+                    season_type, ', '.join(SEASON_TYPES)
+                )
+            )
+            return None
+        return self.client.Stats().get_all_stats(season_type, YEAR)[
+            str(player_id)
+        ]
+
+    def player_week_projection(
+        self, player_id: Union[str, int], season_type: str,
+        week: Union[str, int], scoring_only: bool = False 
+    ) -> dict:
+        """
+            Returns the weekly projections for a player
+        """
+        if season_type not in SEASON_TYPES:
+            logging.warning(
+                "'%s' is not a valid season type. Valid options are: %s".format(
+                    season_type, ', '.join(SEASON_TYPES)
+                )
+            )
+        if scoring_only:
+            return {
+                k: v
+                for k, v in self.client.Stats().get_week_projections(
+                    season_type, YEAR, week
+                )[str(player_id)].items()
+                if k.startswith('pts')
+            }
+        return self.client.Stats().get_week_projections(
+            season_type, YEAR, week
+        )[str(player_id)]
 
 
 def main() -> None:

--- a/src/NFLLunch/sleeper_helper.py
+++ b/src/NFLLunch/sleeper_helper.py
@@ -33,7 +33,6 @@ class SleeperHelper:
         """
             Return all offensive NFL players
         """
-        all_players = self.__get_all_players()
         return {
             d: v
             for d, v in self.__get_all_players().items()
@@ -51,7 +50,7 @@ class SleeperHelper:
                     return player_id
             except KeyError:
                 logging.info(
-                    "KeyError: No 'full_name' for player %s", player_id
+                    f"KeyError: No 'full_name' for player {player_id}"
                 )
                 continue
         return None
@@ -77,13 +76,15 @@ class SleeperHelper:
         """
         if season_type not in SEASON_TYPES:
             logging.warning(
-                "'%s' is not a valid season type. Valid options are: %s".format(
-                    season_type, ', '.join(SEASON_TYPES)
+                (
+                    f"'{season_type}' is not a valid season type. "
+                    f"Valid options are: {', '.join(SEASON_TYPES)}"
                 )
             )
             return None
-        return self.client.Stats().get_week_stats(
-            season_type, YEAR, week)[str(player_id)]
+        return self.client.Stats().get_week_stats(season_type, YEAR, week)[
+            str(player_id)
+        ]
 
     def player_season_stats(
         self, player_id: Union[str, int], season_type: str
@@ -93,8 +94,9 @@ class SleeperHelper:
         """
         if season_type not in SEASON_TYPES:
             logging.warning(
-                "'%s' is not a valid season type. Valid options are: %s".format(
-                    season_type, ', '.join(SEASON_TYPES)
+                (
+                    f"'{season_type}' is not a valid season type. "
+                    f"Valid options are: {', '.join(SEASON_TYPES)}"
                 )
             )
             return None
@@ -104,15 +106,16 @@ class SleeperHelper:
 
     def player_week_projection(
         self, player_id: Union[str, int], season_type: str,
-        week: Union[str, int], scoring_only: bool = False 
+        week: Union[str, int], scoring_only: bool = False
     ) -> dict:
         """
             Returns the weekly projections for a player
         """
         if season_type not in SEASON_TYPES:
             logging.warning(
-                "'%s' is not a valid season type. Valid options are: %s".format(
-                    season_type, ', '.join(SEASON_TYPES)
+                (
+                    f"'{season_type}' is not a valid season type. "
+                    f"Valid options are: {', '.join(SEASON_TYPES)}"
                 )
             )
         if scoring_only:


### PR DESCRIPTION
Add the option to retrieve the weekly stats, season stats, or week projections of a player.
Stats example:
```
>>> client = sleeper_helper.SleeperHelper(sleeper)
>>> client.player_season_stats(1234, 'regular')
{'pass_2pt': 1.0, 'pass_int': 4.0, 'pass_lng': 480.0, 'off_snp': 858.0, 'gs': 12.0, 'cmp_pct': 815.6, 'pass_fd': 123.0, 'gp'
: 12.0, 'pass_sack': 35.0, 'tm_off_snp': 858.0, 'pass_td_40p': 4.0, 'wind_speed': 77.0, 'bonus_pass_cmp_25': 3.0, 'gms_activ
e': 12.0, 'pass_cmp': 258.0, 'pts_half_ppr': 267.4, 'pass_rtg': 1343.32, 'idp_tkl': 1.0, 'pass_sack_yds': 218.0, 'tm_def_snp
': 833.0, 'rush_ypa': 4.98, 'temperature': 685.0, 'rush_fd': 11.0, 'bonus_pass_yd_300': 2.0, 'pass_att': 383.0, 'pass_inc': 
125.0, 'pass_cmp_40p': 8.0, 'pass_ypa': 8.3, 'rush_att': 57.0, 'idp_tkl_solo': 1.0, 'td': 3.0, 'rush_lng': 149.0, 'tm_st_snp
': 243.0, 'rush_yd': 284.0, 'bonus_pass_yd_400': 1.0, 'pass_int_td': 2.0, 'pass_yd': 3177.0, 'pass_td': 26.0, 'rush_td': 3.0
, 'pts_ppr': 267.48, 'fum_lost': 2.0, 'humidity': 673.0, 'fum': 5.0, 'pts_std': 267.48, 'pass_ypc': 12.31}
>>> client.player_week_stats(1234, 'regular', 13)
{'pass_int': 1.0, 'pass_lng': 60.0, 'off_snp': 75.0, 'gs': 1.0, 'cmp_pct': 67.7, 'pass_fd': 6.0, 'gp': 1.0, 'pass_sack': 2.0
, 'tm_off_snp': 75.0, 'pass_td_40p': 1.0, 'wind_speed': 3.0, 'gms_active': 1.0, 'pass_cmp': 21.0, 'pts_half_ppr': 16.9, 'pas
s_rtg': 98.86, 'pass_sack_yds': 14.0, 'tm_def_snp': 55.0, 'rush_ypa': 3.2, 'temperature': 43.0, 'pass_att': 31.0, 'pass_inc'
: 10.0, 'pass_cmp_40p': 1.0, 'pass_ypa': 7.7, 'rush_att': 4.0, 'rush_lng': 7.0, 'tm_st_snp': 25.0, 'rush_yd': 13.0, 'pass_in
t_td': 1.0, 'pass_yd': 240.0, 'pass_td': 2.0, 'pts_ppr': 16.9, 'humidity': 22.0, 'pts_std': 16.9, 'pass_ypc': 11.4}
```
Projections example:
```
>>> client.player_week_projection(1234, 'regular', 14)
{'rush_ypa': 5.5, 'rush_yd': 22.5, 'rush_td': 0.2, 'rush_fd': 2.25, 'rush_att': 4.4, 'pts_std': 19.43, 'pts_ppr': 19.43, 'pt
s_half_ppr': 19.4, 'pass_ypc': 12.1, 'pass_ypa': 7.9, 'pass_yd': 254.4, 'pass_td': 1.8, 'pass_rtg': 110.68, 'pass_int': 0.5,
 'pass_inc': 11.1, 'pass_fd': 25.44, 'pass_cmp': 20.9, 'pass_att': 32.0, 'gs': 1.0, 'gp': 1.0, 'gms_active': 1.0, 'fum_lost'
: 0.2, 'fum': 0.2, 'cmp_pct': 65.6}
>>> client.player_projections(1234, 'regular', 14, True)
{'pts_std': 19.43, 'pts_ppr': 19.43, 'pts_half_ppr': 19.4}
```